### PR TITLE
Fix screen split when rotating the device

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,12 +20,6 @@ export default class App extends Component {
   constructor(props) {
     super(props);
     this.state = {list: {}, current: null, otientation: null};
-    UIManager.setLayoutAnimationEnabledExperimental &&
-      UIManager.setLayoutAnimationEnabledExperimental(true);
-  }
-
-  componentWillUpdate() {
-    LayoutAnimation.easeInEaseOut();
   }
 
   componentDidMount() {

--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -13,15 +13,13 @@ export default class ChannelList extends Component {
       <ListView
         enableEmptySections
         dataSource={dataSource(this.props.list)}
-        renderRow={(channel) => {
-          console.log(channel)
-          return <Channel
+        renderRow={(channel) => (
+          <Channel
             {...channel}
             onSelectChannel={this.props.onChange}
-            selected={
-              this.props.selected === channel.id
-            } />
-        } }
+            selected={this.props.selected === channel.id}
+          />
+        )}
       />
     );
   }


### PR DESCRIPTION
The app was breaking in half when the device got rotated, I assumed this was because of the Layout animation and after removing it I couldn't reproduce the issue anymore so I think this has solved the issue. Anyway the layout animation wasn't adding that much to the app.